### PR TITLE
Adding ability to delete a specified key from Redis. Adding tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,7 @@ await cache.Set("foobar1", item, TimeSpan.FromSeconds(90));
 
 // Get cached item
 var cachedItem = await cache.Get<TestItem>("foobar1");
+
+// Deletes a specified key from the cache.
+await cache.Delete("foobar1");
 ```

--- a/src/AzureCacheRedisClient/AzureCacheRedisClient.csproj
+++ b/src/AzureCacheRedisClient/AzureCacheRedisClient.csproj
@@ -5,13 +5,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<PackageId>DanielLarsenNZ.AzureCacheRedisClient</PackageId>
-	<Version>1.1.1-preview</Version>
-	<Authors>Daniel Larsen</Authors>
+	<Version>1.1.2-preview</Version>
+	<Authors>Daniel Larsen,Will Velida</Authors>
 	<PackageTags>Microsoft;Azure;Azure Cache for Redis; Redis</PackageTags>
 	<Description>A Redis client library that incorporates best practices for Azure Cache for Redis.</Description>
 	<RepositoryUrl>https://github.com/DanielLarsenNZ/AzureCacheRedisClient</RepositoryUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<Copyright>2022 Daniel Larsen</Copyright>
+	<Copyright>2022 Daniel Larsen, Will Velida</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AzureCacheRedisClient/IRedisCache.cs
+++ b/src/AzureCacheRedisClient/IRedisCache.cs
@@ -43,5 +43,13 @@ namespace AzureCacheRedisClient
         /// <param name="value"></param>
         /// <param name="expiry"></param>
         Task Set(string key, object value, TimeSpan expiry);
+
+        /// <summary>
+        /// Deletes the specified key from the cache. A key is ignored if it does not exist. 
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="fireAndForget"></param>
+        /// <returns></returns>
+        Task Delete(string key, bool fireAndForget = false);
     }
 }

--- a/src/AzureCacheRedisClient/RedisDb.cs
+++ b/src/AzureCacheRedisClient/RedisDb.cs
@@ -112,6 +112,20 @@ namespace AzureCacheRedisClient
             await HandleRedis("Db Set", key, () => _db.StringSetAsync(key, JsonSerializer.SerializeToUtf8Bytes(value), expiry, When.Always));
         }
 
+        /// <summary>
+        /// Removes the specified key. If the key does not exist, it is ignored.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="fireAndForget"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public async Task Delete(string key, bool fireAndForget = false)
+        {
+            if (_db == null) throw new InvalidOperationException("Redis Database is not connected. Call Connect(connectionString).");
+
+            await HandleRedis("Db Del", key, () => _db.KeyDeleteAsync(key, fireAndForget ? CommandFlags.FireAndForget : CommandFlags.None));
+        }
+
 
         /// <summary>
         /// Handles Redis exceptions and Tracks dependency calls via Application Insights

--- a/src/AzureCacheRedisClientTests/RedisDbTests.cs
+++ b/src/AzureCacheRedisClientTests/RedisDbTests.cs
@@ -61,6 +61,7 @@ namespace AzureCacheRedisClientTests
         }
 
         [TestMethod]
+        [TestCategory("Integration")]
         public async Task DeleteKey_SuccessfullyRemovesKey()
         {
             IRedisCache cache = new RedisDb(_configuration["AzureCacheRedisConnectionString"], _telemetry);
@@ -76,6 +77,7 @@ namespace AzureCacheRedisClientTests
         }
 
         [TestMethod]
+        [TestCategory("Integration")]
         public async Task DeleteKey_IgnoresKeyWhenItDoesNotExist()
         {
             IRedisCache cache = new RedisDb(_configuration["AzureCacheRedisConnectionString"], _telemetry);

--- a/src/AzureCacheRedisClientTests/RedisDbTests.cs
+++ b/src/AzureCacheRedisClientTests/RedisDbTests.cs
@@ -24,7 +24,7 @@ namespace AzureCacheRedisClientTests
             _configuration = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile(@"appsettings.json", false, false)
-                //.AddJsonFile(@"appsettings.Development.json", true, false)
+                .AddJsonFile(@"appsettings.Development.json", true, false)
                 .Build();
 
             _telemetry = new TelemetryClient(TelemetryConfiguration.CreateDefault());


### PR DESCRIPTION
This PR contains the following changes:

- Adds the ```Delete()``` method to ```IRedisCache.cs``` interface. This method is implemented in ```RedisDb.cs```. The purpose of this method is to remove a specified key from the cache.
- Adds a test called ```DeleteKey_SuccessfullyRemovesKey``` to validate that the method removes the specified key from the cache.
- Adds a test called ```DeleteKey_IgnoresKeyWhenItDoesNotExist``` to validate that the key is ignored when it does not exist in the cache as specified [here](https://redis.io/commands/del).
- Updates ```README.md``` to include the new ```Delete()``` method.