### PR TITLE
Adding Decrement functionality to IRedisDB interface. Implementing tests

### DIFF
--- a/src/AzureCacheRedisClient/AzureCacheRedisClient.csproj
+++ b/src/AzureCacheRedisClient/AzureCacheRedisClient.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<PackageId>DanielLarsenNZ.AzureCacheRedisClient</PackageId>
-	<Version>1.2.0-preview</Version>
+	<Version>1.2.1-preview</Version>
 	<Authors>Daniel Larsen,Will Velida</Authors>
 	<PackageTags>Microsoft;Azure;Azure Cache for Redis; Redis</PackageTags>
 	<Description>A Redis client library that incorporates best practices for Azure Cache for Redis.</Description>

--- a/src/AzureCacheRedisClient/IRedisDb.cs
+++ b/src/AzureCacheRedisClient/IRedisDb.cs
@@ -3,5 +3,6 @@
     internal interface IRedisDb : IRedisCache
     {
         Task<long> Increment(string key, long increment = 1, bool fireAndForget = false);
+        Task<long> Decrement(string key, long decrement = 1, bool fireAndForget = false);
     }
 }

--- a/src/AzureCacheRedisClient/RedisDb.cs
+++ b/src/AzureCacheRedisClient/RedisDb.cs
@@ -100,6 +100,22 @@ namespace AzureCacheRedisClient
         }
 
         /// <summary>
+        /// Decrements the <see cref="long"/> number stored at <paramref name="key"/> by <paramref name="decrement"/> .
+        /// If the key does not exist, it is set to 0 before performing the operation.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="increment">The amount to decrement by (defaults to 1).</param>
+        /// <param name="fireAndForget">When true, the caller will immediately receive a default-value. This value is not indicative of anything at the server.</param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public async Task<long> Decrement(string key, long decrement = 1, bool fireAndForget = false)
+        {
+            if (_db == null) throw new InvalidOperationException("Redis Database is not connected. Call Connect(connectionString).");
+
+            return await HandleRedis("Db Decrement", key, () => _db.StringDecrementAsync(key, decrement, fireAndForget ? CommandFlags.FireAndForget : CommandFlags.None));
+        }
+
+        /// <summary>
         /// Sets a value in Cache, overwriting any existing value if same key exists.
         /// </summary>
         /// <param name="key"></param>

--- a/src/AzureCacheRedisClientTests/RedisDbTests.cs
+++ b/src/AzureCacheRedisClientTests/RedisDbTests.cs
@@ -220,9 +220,11 @@ namespace AzureCacheRedisClientTests
         {
             IRedisDb cache = new RedisDb(_configuration["AzureCacheRedisConnectionString"]);
 
-            Assert.AreEqual(1, await cache.Increment(Guid.NewGuid().ToString("N")));
+            string key = Guid.NewGuid().ToString("N");
 
-            //TODO: Cleanup key
+            Assert.AreEqual(1, await cache.Increment(key));
+
+            await cache.Delete(key);
         }
 
         [TestMethod]
@@ -231,11 +233,13 @@ namespace AzureCacheRedisClientTests
         {
             const long number = 5;
 
+            string key = Guid.NewGuid().ToString("N");
+
             IRedisDb cache = new RedisDb(_configuration["AzureCacheRedisConnectionString"]);
 
-            Assert.AreEqual(number, await cache.Increment(Guid.NewGuid().ToString("N"), number));
+            Assert.AreEqual(number, await cache.Increment(key, number));
 
-            //TODO: Cleanup key
+            await cache.Delete(key);
         }
 
         [TestMethod]
@@ -260,6 +264,56 @@ namespace AzureCacheRedisClientTests
 
             Assert.AreEqual(default, await cache.Increment(nameof(Increment_ValueSet_ReturnsPlus1), 5, fireAndForget: true));
 
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        public async Task Decrement_NoValueSet_ReturnsMinus1()
+        {
+            IRedisDb cache = new RedisDb(_configuration["AzureCacheRedisConnectionString"]);
+
+            string key = Guid.NewGuid().ToString("N");
+
+            Assert.AreEqual(-1, await cache.Decrement(key));
+
+            await cache.Delete(key);
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        public async Task Decrement_NoValueSetDecrement5_ReturnsMinus5()
+        {
+            const long number = 5;
+
+            string key = Guid.NewGuid().ToString("N");
+
+            IRedisDb cache = new RedisDb(_configuration["AzureCacheRedisConnectionString"]);
+
+            Assert.AreEqual(-5, await cache.Decrement(key, number));
+
+            await cache.Delete(key);
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        public async Task Decrement_ValueSet_ReturnMinus1()
+        {
+            const long number = 1;
+
+            IRedisDb cache = new RedisDb(_configuration["AzureCacheRedisConnectionString"]);
+
+            await cache.Set(nameof(Decrement_ValueSet_ReturnMinus1), number, TimeSpan.FromSeconds(1));
+
+            Assert.AreEqual(number - 1, await cache.Decrement(nameof(Decrement_ValueSet_ReturnMinus1)));
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        public async Task Decrement_Decrement5FireAndForget_Returns0()
+        {
+            IRedisDb cache = new RedisDb(_configuration["AzureCacheRedisConnectionString"]);
+
+            Assert.AreEqual(default, await cache.Decrement(nameof(Decrement_ValueSet_ReturnMinus1), 5, fireAndForget: true));
         }
 
         [TestMethod]


### PR DESCRIPTION
This PR implements the `Decrement()` functionality as part of the `IRedisDb` interface. This has been raised as part of the response to issue #5. 

This PR contains the following changes:

- Implementing the `Decrement()` method in the `IRedisDb` interface.
- Implements the `Decrement()` functionality in `RedisDb.cs`.
- Includes test cases for decrementing when no value is set, decrementing when a decrement value is provided, fire and forget and decrement when value is set.
- Adds the Delete functionality in Increment and Decrement test cases to clean up the key from the test cache.
- Increments minor version in csproj file.